### PR TITLE
Fix small typo for hmTouchEvents to hmTouchevents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Angular Hammer 
 ===============
 
@@ -12,7 +11,7 @@ You can change the default settings for the instance by adding a second attribut
 
     hm-options="{drag: false, transform: false}"
 
-Include the angular-hammer.js file, and add `hmTouchEvents` to your app’s dependencies.
+Include the angular-hammer.js file, and add `hmTouchevents` to your app’s dependencies.
 
 Requires Hammer.js, tested with `v1.0.1 - 2013-02-26`.
 


### PR DESCRIPTION
Small typo in the docs to inject the hammer dependency.
